### PR TITLE
fix(prawn): handle missing bank gracefully

### DIFF
--- a/lib/vesr/prawn/esr_recipe.rb
+++ b/lib/vesr/prawn/esr_recipe.rb
@@ -7,8 +7,10 @@ module Prawn
     include ActionView::Helpers::TranslationHelper
 
     def draw_account_detail(bank, sender, print_payment_for)
-      text bank.vcard.full_name
-      text bank.vcard.postal_code + " " + bank.vcard.locality
+      if bank
+        text bank.vcard.full_name
+        text bank.vcard.postal_code + " " + bank.vcard.locality
+      end
 
       text " "
       if print_payment_for


### PR DESCRIPTION
When no bank is assigned to the BankAccount we should not raise an
exception, but skip the relevant output.
