### PR TITLE
use the event name instead of the object

### DIFF
--- a/app/views/esr_records/_esr_record.html.haml
+++ b/app/views/esr_records/_esr_record.html.haml
@@ -7,4 +7,4 @@
   %td.currency= currency_fmt(esr_record.invoice.balance.currency_round) if esr_record.invoice
   %td.action-links
     - esr_record.aasm.events.each do |event|
-      = link_to image_tag("16x16/#{event}.png"), polymorphic_url([event, esr_record]), :remote => true, :method => :post, :title => t_action(event)
+      = link_to image_tag("16x16/#{event.name}.png"), polymorphic_url([event.name, esr_record]), :remote => true, :method => :post, :title => t_action(event.name)


### PR DESCRIPTION
This prevents the error `undefined method `model_name' for AASM::Core::Event:Class`.
