### PR TITLE
Import only LSV credit records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ doc
 # jeweler generated
 pkg
 
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
+# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore:
 #
 # * Create a file at ~/.gitignore
 # * Include files you want ignored
@@ -46,3 +46,5 @@ pkg
 
 # For rubinius:
 #*.rbc
+
+/spec/examples.txt

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,29 @@
 PATH
   remote: .
   specs:
-    vesr (0.13.1)
+    vesr (1.0.0)
       aasm (~> 4.1)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    aasm (4.1.0)
+    aasm (4.5.1)
+    diff-lcs (1.2.5)
     rake (0.9.2)
     rdoc (3.9.4)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.1)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
 
 PLATFORMS
   ruby
@@ -17,4 +31,8 @@ PLATFORMS
 DEPENDENCIES
   rake
   rdoc
+  rspec (~> 3.4.0)
   vesr!
+
+BUNDLED WITH
+   1.10.6

--- a/app/models/esr_record.rb
+++ b/app/models/esr_record.rb
@@ -1,6 +1,10 @@
 # encoding: utf-8
 
 class EsrRecord < ActiveRecord::Base
+  SUPPORTED_RECORD_TYPES = [
+    :lsv_credit
+  ]
+
   # Access restrictions
   attr_accessible :file, :remarks
 
@@ -40,6 +44,11 @@ class EsrRecord < ActiveRecord::Base
   scope :unsolved, where(:state => ['overpaid', 'underpaid', 'missing'])
   scope :valid, where(:state => 'paid')
 
+  def self.supported_line?(line)
+    record_type_code = line[0..2]
+    record_type = EsrRecordTypes.lookup_code record_type_code
+    SUPPORTED_RECORD_TYPES.include?(record_type)
+  end
 
   private
   def parse_date(value)

--- a/app/models/esr_record_types.rb
+++ b/app/models/esr_record_types.rb
@@ -1,0 +1,29 @@
+module EsrRecordTypes
+  RECORD_TYPES = {
+    esr_e_banking_credit: '002',
+    esr_e_banking_cancellation: '005',
+    esr_e_banking_correction: '008',
+    esr_post_office_counter_credit: '012',
+    esr_post_office_counter_cancellation: '015',
+    esr_post_office_counter_correction: '018',
+
+    esr_plus_e_banking_credit: '102',
+    esr_plus_e_banking_cancellation: '105',
+    esr_plus_e_banking_correction: '108',
+    esr_plus_post_office_counter_credit: '112',
+    esr_plus_post_office_counter_cancellation: '115',
+    esr_plus_post_office_counter_correction: '118',
+
+    lsv_credit: '202',
+    lsv_cancellation: '205',
+
+    total_record_credit: '999',
+    total_record_cancellation: '995',
+  }
+
+  def self.lookup_code(lookup_code)
+    RECORD_TYPES.each do |name, code|
+      return name if code == lookup_code
+    end
+  end
+end

--- a/spec/models/esr_record_types_spec.rb
+++ b/spec/models/esr_record_types_spec.rb
@@ -1,0 +1,11 @@
+require './app/models/esr_record_types'
+
+RSpec.describe EsrRecordTypes do
+  describe '.lookup_code' do
+    let(:code) { '202' }
+
+    subject { EsrRecordTypes.lookup_code(code) }
+
+    it { is_expected.to eq(:lsv_credit) }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,22 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+
+  config.example_status_persistence_file_path = 'spec/examples.txt'
+  config.disable_monkey_patching!
+
+  if config.files_to_run.one?
+    config.default_formatter = 'doc'
+  end
+
+  config.order = :random
+  Kernel.srand config.seed
+end

--- a/vesr.gemspec
+++ b/vesr.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aasm', '~> 4.1'
 
   s.extra_rdoc_files = ["README.rdoc", "LICENSE.txt"]
+
+  s.add_development_dependency 'rspec', '~> 3.4.0'
 end


### PR DESCRIPTION
The code currently supports only to import LSV credit records because:
- It does not handle `payment_tax`
- It does not handle cancellations
- The total record is not used to validate the import

This PR will make sure only those records are imported which are fully supported.
