### PR TITLE
Move ESR number handling into classes

### DIFF
--- a/lib/vesr/reference_builder.rb
+++ b/lib/vesr/reference_builder.rb
@@ -1,0 +1,35 @@
+require 'vesr/validation_digit_calculator'
+
+module VESR
+  class ReferenceBuilder
+    def self.call(customer_id, invoice_id, esr_id)
+      new(customer_id, invoice_id, esr_id).call
+    end
+
+    attr_reader :customer_id, :invoice_id, :esr_id
+
+    def initialize(customer_id, invoice_id, esr_id)
+      @customer_id = customer_id
+      @invoice_id = invoice_id
+      @esr_id = esr_id
+    end
+
+    def call
+      "#{esr_id}#{formatted_customer_id}#{formatted_invoice_id}"
+    end
+
+    private
+
+    def formatted_customer_id
+      format "%0#{customer_id_length}i", customer_id
+    end
+
+    def customer_id_length
+      19 - esr_id.to_s.length
+    end
+
+    def formatted_invoice_id
+      format '%07i', invoice_id
+    end
+  end
+end

--- a/lib/vesr/validation_digit_calculator.rb
+++ b/lib/vesr/validation_digit_calculator.rb
@@ -1,0 +1,20 @@
+module VESR
+  class ValidationDigitCalculator
+    # Defined at http://www.pruefziffernberechnung.de/E/Einzahlungsschein-CH.shtml
+
+    ESR9_TABLE = [0, 9, 4, 6, 8, 2, 7, 1, 3, 5]
+
+    def self.call(value)
+      value = value.to_s
+
+      digit = 0
+      value.split('').each do |char|
+        current_digit = digit + char.to_i
+        digit = ESR9_TABLE[current_digit % 10]
+      end
+      digit = (10 - digit) % 10
+
+      "#{value}#{digit}"
+    end
+  end
+end

--- a/spec/lib/vesr/reference_builder_spec.rb
+++ b/spec/lib/vesr/reference_builder_spec.rb
@@ -1,0 +1,14 @@
+require 'vesr/reference_builder'
+
+RSpec.describe VESR::ReferenceBuilder do
+  let(:customer_id) { 4 }
+  let(:invoice_id) { 44 }
+  let(:esr_id) { '12000000' }
+  let(:instance) { described_class.new(customer_id, invoice_id, esr_id) }
+
+  describe '#call' do
+    subject { instance.call }
+
+    it { is_expected.to eq('12000000000000000040000044') }
+  end
+end

--- a/spec/lib/vesr/reference_builder_spec.rb
+++ b/spec/lib/vesr/reference_builder_spec.rb
@@ -6,6 +6,17 @@ RSpec.describe VESR::ReferenceBuilder do
   let(:esr_id) { '12000000' }
   let(:instance) { described_class.new(customer_id, invoice_id, esr_id) }
 
+  describe '.call' do
+    let(:reference_builder_double) { instance_double(described_class) }
+
+    it 'initializes a new instance and calls `#call`' do
+      expect(described_class).
+        to receive(:new).with(customer_id, invoice_id, esr_id).and_return(reference_builder_double)
+      expect(reference_builder_double).to receive(:call)
+      described_class.call(customer_id, invoice_id, esr_id)
+    end
+  end
+
   describe '#call' do
     subject { instance.call }
 

--- a/spec/lib/vesr/validation_digit_calculator_spec.rb
+++ b/spec/lib/vesr/validation_digit_calculator_spec.rb
@@ -1,0 +1,22 @@
+require 'vesr/validation_digit_calculator'
+
+RSpec.describe VESR::ValidationDigitCalculator do
+  describe '.call' do
+    subject { described_class.call(value) }
+
+    context '1' do
+      let(:value) { '1' }
+      it { is_expected.to eq('11') }
+    end
+
+    context '12345678' do
+      let(:value) { '12345678' }
+      it { is_expected.to eq('123456786') }
+    end
+
+    context '12000000000000000040000044' do
+      let(:value) { '12000000000000000040000044' }
+      it { is_expected.to eq('120000000000000000400000448') }
+    end
+  end
+end


### PR DESCRIPTION
This way the code becomes reusable and we can use it also at other places than `Prawn::EsrRecipe`.
